### PR TITLE
Add README with build and run instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,47 @@
+# pharmChart
+
+## Project Purpose
+
+`pharmChart` provides a desktop GUI to manage medication rounds using a Python interface built with PyQt6. A Three.js based frontend visualizes a 3D model of the medicine cart and is served via a small Node/Express server. Data is stored in a local SQLite database defined in `carrello.sql`.
+
+## Prerequisites
+
+- **Python**: version 3.10 or later. Install dependencies such as `PyQt6` via `pip install PyQt6`.
+- **Node.js**: version 18+ (the Dockerfile uses Node 20). Run `npm install` in the project directory to fetch required packages.
+
+## Building the Frontend
+
+Compile the Three.js frontend and place the output in `public/`:
+
+```bash
+npm run build
+```
+
+The server can then be started with:
+
+```bash
+npm start
+```
+
+which serves the bundled files on [http://localhost:3000](http://localhost:3000).
+
+## Running the GUI
+
+With the Node server running, launch the PyQt6 application:
+
+```bash
+python main.py
+```
+
+The GUI embeds the web frontend through `QWebEngineView` and connects to the local SQLite database. The first launch initializes the database if needed.
+
+## Optional Docker Usage
+
+A `Dockerfile` and `docker-compose.yml` are provided. To build and run the Node server using Docker:
+
+```bash
+docker-compose up
+```
+
+This performs `npm run build` inside the container and exposes port `3000` on the host. You can still run `python main.py` locally to access the web component served by Docker.
+


### PR DESCRIPTION
## Summary
- document project purpose and environment prerequisites
- add instructions for building the frontend, running the GUI, and using Docker

## Testing
- `npm run build`
- `python -m py_compile main.py create_db.py`


------
https://chatgpt.com/codex/tasks/task_e_68727aa25eb08325b6e6dbf03aa11a57